### PR TITLE
added script to assign the view buttons

### DIFF
--- a/Assets/Scripts/Menus/SC_CameraViewButton.cs
+++ b/Assets/Scripts/Menus/SC_CameraViewButton.cs
@@ -1,0 +1,46 @@
+using CameraSystem;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SC_CameraViewButton : MonoBehaviour
+{
+    private SC_CameraManager _cameraManager;
+    private Button _button;
+
+    private void Start()
+    {
+        TryToAssignCameraManager();
+        TryToAssignButton();
+
+        SubscribeOnClick();
+    }
+
+    private void TryToAssignCameraManager()
+    {
+        if (_cameraManager != null) return;
+
+        if (SC_CameraManager.Instance == null)
+        {
+            Debug.LogWarning("SC_CameraManager instance is missing!");
+            return;
+        }
+
+        _cameraManager = SC_CameraManager.Instance;
+    }
+
+    private void TryToAssignButton()
+    {
+        if (_button != null) return;
+
+        if (!this.TryGetComponent<Button>(out _button))
+        {
+            Debug.LogWarning("Button instance is missing!");
+            return;
+        }
+    }
+
+    private void SubscribeOnClick() => _button.onClick.AddListener(AssignAction);
+    private void UnsubscribeOnClick() => _button.onClick.RemoveListener(AssignAction);
+
+    private void AssignAction() => _cameraManager.ViewerToMainView();
+}

--- a/Assets/Scripts/Menus/SC_CameraViewButton.cs.meta
+++ b/Assets/Scripts/Menus/SC_CameraViewButton.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4fd82ada7cfeef340ac830fb35b9c6c4

--- a/Assets/TemporaryInterfaceTesting/ReturnButton.prefab
+++ b/Assets/TemporaryInterfaceTesting/ReturnButton.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 5774525226284584924}
   - component: {fileID: 6205373947119716858}
   - component: {fileID: 8179373677527355269}
+  - component: {fileID: 2528253851983959061}
   m_Layer: 0
   m_Name: ReturnButton
   m_TagString: Untagged
@@ -133,6 +134,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &2528253851983959061
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467069917939732633}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4fd82ada7cfeef340ac830fb35b9c6c4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4594724693310338264
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
When restarting the view return buttons wouldn't have the CameraManager assigned anymore.

So by addeding a script that adds them to the click event the problem is fixed